### PR TITLE
Prepare Francisco-Gamino/in-proc-test5 branch for VNext: Clear notes, update version to 4.40.100

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,16 +1,5 @@
-### Release notes
+    ### Release notes
+
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
-- Updated System.Memory.Data reference to 6.0.0 and 8.0.1 for .NET 6 and .NET 8, respectively.
-- Update Python Worker Version to *An external link was removed to protect your privacy.*
-- Added fallback behavior to ensure in-proc payload compatibility with "dotnet-isolated" as the `FUNCTIONS_WORKER_RUNTIME` value (#10439)
-- Update Node.js Worker Version to *An external link was removed to protect your privacy.*
-- Implement host configuration property to allow configuration of the metadata provider timeout period (#10526)
-- The value can be set via `metadataProviderTimeout` in host.json and defaults to "00:00:30" (30 seconds).
-- For logic apps, unless configured via the host.json, the timeout is disabled by default.
-- Added support for identity-based connections to Diagnostic Events (#10438)
-- Update PowerShell 7.2 worker to *An external link was removed to protect your privacy.*
-- Update PowerShell 7.4 worker to *An external link was removed to protect your privacy.*
-- Do not unregister gRPC extension endpoints on host shutdown.
-- Updated System.Memory.Data reference to 6.0.0 and 8.0.1 for .NET 6 and .NET 8, respectively.

--- a/src/Directory.Version.props
+++ b/src/Directory.Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>4.1035.0</VersionPrefix>
+    <VersionPrefix>4.40.100</VersionPrefix>
     <UpdateBuildNumber>true</UpdateBuildNumber>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

This PR contains the following changes:
- Update version to 4.40.100
- Clear release notes

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the in-proc branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the in-proc branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to elease_notes.md
        * [x] My changes **do not** need to be backported to a previous version
        * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
        * [x] My changes **do not** require diagnostic events changes
        * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
        * [ ] I have added all required tests (Unit tests, E2E tests)

        <!-- Optional: delete if not applicable  -->
        ### Additional information

        Additional PR information